### PR TITLE
Strip 900Mb from the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.dockerignore
+Dockerfile
+README.md
+screenshot.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,8 @@ FROM python
 
 WORKDIR /app/
 
-COPY scripts ./scripts
-COPY requirements.txt ./
+COPY . /app/
 RUN /app/scripts/build
 
-COPY main.py ./
-COPY templates ./templates
 CMD ["/app/scripts/serve"]
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
-FROM python
+FROM python:3.10-alpine
 
 WORKDIR /app/
 
 COPY . /app/
-RUN /app/scripts/build
+RUN pip install --upgrade pip
+
+# requirements.txt lists `cryptography` which needs `cffi`
+# which doesn't have a musl (Alpine) wheel and needs `gcc`
+# and libs for installation from source
+RUN apk add --update --no-cache --virtual .build-deps \
+      gcc musl-dev libffi-dev \
+    && /app/scripts/build \
+    && apk del .build-deps
 
 CMD ["/app/scripts/serve"]
 EXPOSE 8000

--- a/scripts/build
+++ b/scripts/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 

--- a/scripts/serve
+++ b/scripts/serve
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 


### PR DESCRIPTION
Before.
```
docker.io/ewjoachim/notgithub-token-scanning   latest                 39c3543e2709  8 months ago    997 MB
```
After.
```
docker.io/ewjoachim/notgithub-token-scanning   latest                 a05a9b33a8b9  10 seconds ago  94.1 MB
```

To reduce download size and improve developer's experience on PyPI.

<!-- /spent 4h -->